### PR TITLE
Request: use COPYING for gopkg license indexing check

### DIFF
--- a/vex/COPYING
+++ b/vex/COPYING
@@ -1,0 +1,46 @@
+Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+option.
+
+----------------------------------------------------------------------------------------
+Apache License, Version 2.0
+----------------------------------------------------------------------------------------
+
+Copyright (c) 2025 The Vex Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----------------------------------------------------------------------------------------
+MIT License
+----------------------------------------------------------------------------------------
+
+Copyright (c) 2025 The Vex Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vex/LICENSE-APACHE
+++ b/vex/LICENSE-APACHE
@@ -1,1 +1,0 @@
-../LICENSE-APACHE

--- a/vex/LICENSE-MIT
+++ b/vex/LICENSE-MIT
@@ -1,1 +1,0 @@
-../LICENSE-MIT


### PR DESCRIPTION
Vex documentation gets automatically indexed and uploaded to https://pkg.go.dev/github.com/moderncode-source/vex-svc/vex. It will not be visible unless a redistributable license is found in the package source. Since this repo's licenses are located in the root directory, I will try adding symlinks to them from the `vex` subdirectory. Hopefully, this will make the license check succeed.